### PR TITLE
Mobile UI fix for AnimalReportProfile and userMessage pages

### DIFF
--- a/client/app/animal/[id]/AnimalReportProfile.module.css
+++ b/client/app/animal/[id]/AnimalReportProfile.module.css
@@ -255,3 +255,156 @@
   background-color: #e0cab1;
   margin: 1rem 0;
 }
+/* Mobile styles */
+@media (max-width: 768px) {
+  .container {
+    min-height: 100vh; /* Full viewport height */
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    background-color: #fef4e8;
+    padding: 0.25rem; /* Reduced padding */
+  }
+
+  .card {
+    border: 1px solid #ddd7c0;
+    border-radius: 15px;
+    overflow: hidden;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+    background: linear-gradient(135deg, #fefaf2 0%, #f5e9dc 100%);
+    background-image: url('/paw-pattern.jpg');
+    padding: 0.5rem; /* Reduced padding for tighter fit */
+    width: 100%;
+    max-width: 100%;
+    margin: 0.25rem auto; /* Reduced margin */
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem; /* Reduced gap */
+  }
+
+  /* Image section */
+  .imageWrapper img {
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    object-fit: cover;
+    border-radius: 8px;
+    border: 2px solid #ccc;
+    margin-bottom: 0.25rem; /* Reduced margin-bottom */
+  }
+
+  /* Title section */
+  .cardTitle {
+    font-size: 1.3rem; /* Smaller font size */
+    font-weight: bold;
+    text-align: center;
+    margin-bottom: 0.5rem; /* Reduced margin */
+  }
+
+  .description {
+    font-size: 0.8rem; /* Smaller font size */
+    color: #4a4a4a;
+    text-align: center;
+    padding: 0.3rem; /* Reduced padding */
+    background-color: #fdf8f3;
+    border-radius: 10px;
+    border: 1px solid #ddd7c0;
+  }
+
+  /* Button */
+  .btn {
+    background-color: #ff6f61;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    padding: 0.4rem 0.8rem; /* Reduced padding */
+    font-size: 0.8rem; /* Smaller font size */
+    cursor: pointer;
+    margin: 0.1rem top 0.1rem bottom; /* Reduced margin */
+    width: 100%;
+    max-width: 200px; /* Reduced width */
+  }
+
+  /* Right Section */
+  .rightSection {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem; /* Reduced gap */
+    width: 100%;
+    margin: 0.5rem 0; /* Reduced margin */
+  }
+
+  .listGroupItem {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    background-color: rgba(255, 255, 255, 0.8);
+    padding: 0.4rem; /* Reduced padding */
+    border-radius: 5px;
+    margin-bottom: 0.25rem; /* Reduced margin */
+    font-size: 0.8rem; /* Smaller font size */
+    border: 1px solid #ddd7c0;
+  }
+
+  .label {
+    font-weight: bold;
+    color: #555;
+  }
+
+  .value, .statusBadge {
+    font-weight: normal;
+    color: #333;
+  }
+
+  .statusBadge {
+    background-color: #ff6f61;
+    color: white;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.8rem; /* Smaller font size */
+  }
+
+  /* Map */
+  .mapContainer {
+    width: 100%;
+    height: 50vh; /* Reduced height for better fitting */
+    border-radius: 8px;
+    overflow: hidden;
+    margin-top: 1rem;
+  }
+
+  /* Overlay */
+  .overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .overlayContent {
+    background: #fff;
+    padding: 1rem;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 350px; /* Reduced width for compactness */
+  }
+
+  /* Close Button */
+  .closeButton {
+    background: transparent;
+    border: none;
+    font-size: 1.5rem;
+    color: #333;
+    cursor: pointer;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
+}

--- a/client/app/reportAnimal/components/ReportAnimal.js
+++ b/client/app/reportAnimal/components/ReportAnimal.js
@@ -440,19 +440,20 @@ const ReportAnimal = () => {
                                     </GoogleMap>
                                 </LoadScriptNext>
                             </div>
-                            <div className="mb-3">
-                                <label htmlFor="file" className="form-label">
-                                    Upload Image (optional)
-                                </label>
-                                <input
-                                    type="file"
-                                    className="form-control"
-                                    id="file"
-                                    name="file"
-                                    accept="image/*"
-                                    onChange={handleFileChange}
-                                />
-                            </div>
+                    <div className="mb-3">
+                        <label htmlFor="file" className="form-label">
+                            Take or Upload an Image (optional)
+                        </label>
+                        <input
+                            type="file"
+                            className="form-control"
+                            id="file"
+                            name="file"
+                            accept="image/*"
+                            capture="user" // Allows taking pictures from the front camera if supported
+                            onChange={handleFileChange}
+                        />
+                    </div>
                             <button
                                 type="submit"
                                 className="btn btn-primary"

--- a/client/app/userMessages/messagePanel.module.css
+++ b/client/app/userMessages/messagePanel.module.css
@@ -242,3 +242,31 @@
   text-decoration: none;
   cursor: pointer;
 }
+@media (max-width: 768px) {
+  .messagePanel {
+    width: 100%; /* Full width on mobile */
+    height: calc(100vh - 60px); /* Adjust height for smaller screens */
+    padding: 10px;
+  }
+  .messageInputContainer {
+    gap: 5px; /* Smaller gap on mobile */
+  }
+  .messageBubble {
+    padding: 8px; /* Smaller padding on mobile */
+    font-size: 0.9rem; /* Adjust font size */
+  }
+
+  .messageInput {
+    font-size: 0.9rem;
+    padding: 10px;
+  }
+    .animalReportPreview {
+    max-width: 100%; /* Full width on mobile */
+    flex-direction: column;
+  }
+
+  .animalImage {
+    width: 100%; /* Full width for images */
+    height: 100px; /* Adjust height */
+  }
+}

--- a/client/app/userMessages/messagingLayout.module.css
+++ b/client/app/userMessages/messagingLayout.module.css
@@ -32,3 +32,26 @@
     font-weight: bold;
   }
   
+  @media (max-width: 600px) {
+    .userListItem {
+      padding: 8px; /* Smaller padding */
+    }
+    
+    .userListItem.active {
+      font-weight: normal; /* Remove bold for better readability */
+    }
+  
+  .messagingLayout {
+    flex-direction: column; /* Stack user list and message panel */
+    height: auto; /* Adjust height */
+  }
+
+  .userList {
+    width: 50%; /* Full width for mobile */
+    margin-bottom: 15px; /* Add space between user list and messages */
+  }
+
+  .messageWrapper {
+    max-width: 100%; /* Full width for messages */
+  }
+  }

--- a/client/app/userMessages/userList.module.css
+++ b/client/app/userMessages/userList.module.css
@@ -118,3 +118,21 @@
   flex-direction: column;
   justify-content: center;
 }
+@media (max-width: 600px) {
+  .header {
+    font-size: 1.8rem; /* Smaller font size on mobile */
+    margin-bottom: 0.8rem;
+  }
+  .userList {
+    width: 100%;
+    border-right: none;
+    padding: 10px;
+  }
+  .userListItem {
+    padding: 10px; /* Smaller padding on mobile */
+  }
+  .profileIcon, .bubbleProfileImage {
+    width: 20px;
+    height: 20px;
+  }
+}


### PR DESCRIPTION
## Description
Enhanced dimensions and layout for mobile view of the animal report profile and the messaging UI.

## What's in this change?
Updated the AnimalReportProfile (ARP) and userMessage CSS files to align all the containers with their respective text. 
- For ARP, the image is no longer narrow and fits the entire screen. All listed elements, corresponding text, and badges fit into the containers.
- For userMessage, the user list is positioned at the top, with the chat interface below it. The send button is no longer cut off.
- Optimized for screens with various widths, with a minimum width of 344px, ensuring all elements fit without overcrowding.

**Note:** The smallest available width in my dimension options was 344px. All other dimensions, including those for various iPhone models, display the layout cleanly. Including iPhone 14 Pro Max shown in the images below!

## Testing changes
- Fixed an issue where the map was getting cut off and there was a scrollbar bug on all the listed groups.
- Reduced width to eliminate gaps between each item.

## Before
![image](https://github.com/user-attachments/assets/18b9e97b-a619-420c-84bb-07cb7c6a0a32)
## After
![image](https://github.com/user-attachments/assets/0e316bec-aa59-425b-b0cb-5d3777b16d6c)
![image](https://github.com/user-attachments/assets/716421fd-a7b3-49db-bc24-a23199d09818)

