### PR TITLE
Truncate Long Descriptions on Animal Cards

### DIFF
--- a/client/app/Strays/components/Strays.css
+++ b/client/app/Strays/components/Strays.css
@@ -1,5 +1,6 @@
 .container {
     margin-top: 20px;
+    max-width: 96%; /* This is what makes the stray cards bigger! Don't remove! */
 }
 /* Tab Styling */
 .tab-buttons {

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -287,3 +287,13 @@ body {
     flex: 1;
     height: 20px;
 }
+
+.card-text {
+    overflow: hidden; /* Hides any overflowing content */
+    white-space: nowrap; /* Prevents the text from wrapping to the next line */
+    text-overflow: ellipsis; /* Adds "..." at the end of the truncated text */
+    display: block; /* Ensures it's treated as a block element */
+    max-width: 100%; /* Ensures it stays within the card's width */
+    font-size: 0.9rem; /* Optional: Adjust the font size if needed */
+    color: #555; /* Optional: Adjust text color */
+}


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/b29a884b-dac0-4a51-bd53-bd475aef8a35)


This PR addresses the issue where long descriptions on animal cards caused layout distortions, such as pushing the "Read More" and comment icons off the card or breaking the design's proportions. The following updates have been made:

- **CSS Update:** Implemented `text-overflow: ellipsis`, `overflow: hidden`, and `white-space: nowrap` to truncate descriptions that exceed a single line, ensuring they are displayed with an ellipsis (`...`) for better readability.
- **UI Consistency:** Maintained the proportional layout of the cards without affecting the placement of other elements like icons or buttons.
