### PR TITLE
Add Info Icon and Modal to Strays Page

### DIFF
--- a/client/app/Strays/components/Modal.js
+++ b/client/app/Strays/components/Modal.js
@@ -1,0 +1,16 @@
+import styles from './Modal.module.css';
+
+const Modal = ({ children, onClose }) => {
+    return (
+        <div className={styles['modal-overlay']} onClick={onClose}>
+            <div className={styles['modal-content']} onClick={(e) => e.stopPropagation()}>
+                <button className={styles['modal-close-button']} onClick={onClose}>
+                    &times;
+                </button>
+                {children}
+            </div>
+        </div>
+    );
+};
+
+export default Modal;

--- a/client/app/Strays/components/Modal.module.css
+++ b/client/app/Strays/components/Modal.module.css
@@ -1,0 +1,63 @@
+/* Modal overlay to darken the background */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+/* Modal content container */
+.modal-content {
+    background: white;
+    padding: 20px 30px; /* Add padding for spacing */
+    border-radius: 10px;
+    max-width: 500px;
+    width: 90%;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+    position: relative;
+    text-align: left; /* Align all content to the left */
+}
+
+/* Center the modal header */
+.modal-content h2 {
+    text-align: center; /* Center-align the header */
+    margin-bottom: 20px; /* Add spacing below the header */
+}
+
+/* Close button styling */
+.modal-close-button {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    font-size: 1.5rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #f85d04; /* Custom color for the close button */
+    transition: color 0.3s ease;
+}
+
+.modal-close-button:hover {
+    color: #d43d01; /* Darker shade for hover effect */
+}
+
+/* Add spacing between paragraphs and the list */
+.modal-content p {
+    margin: 10px 0; /* Add vertical spacing */
+    line-height: 1.6; /* Improve readability */
+}
+
+.modal-content ul {
+    margin-left: 20px; /* Indent the list */
+    padding-left: 0; /* Remove default padding */
+}
+
+.modal-content li {
+    margin-bottom: 10px; /* Add space between list items */
+}

--- a/client/app/Strays/components/Strays.css
+++ b/client/app/Strays/components/Strays.css
@@ -34,3 +34,35 @@
     color: white;
   }
   
+  /* Header container for alignment */
+.strays-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+/* Unique class for the info icon container */
+.strays-info-icon-container {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+/* Info icon styling */
+.strays-info-icon {
+  font-size: 2rem; /* Larger size for better visibility */
+  color: #6c757d; /* Matches the active tab color */
+  margin-right: 20px; /* Add spacing to the right */
+  transition: color 0.3s ease, transform 0.2s ease;
+}
+
+.strays-info-icon:hover {
+  color: #e85d04; /* Highlight on hover */
+  transform: scale(1.1); /* Slight zoom effect */
+}
+
+/* Ensure the filter dropdown aligns properly */
+.dropdown {
+  flex-grow: 1;
+}

--- a/client/app/Strays/components/Strays.js
+++ b/client/app/Strays/components/Strays.js
@@ -1,6 +1,8 @@
 import { useEffect, useState, memo } from 'react'
 import Loader from '../../components/loader/Loader';
 import AnimalCard from '../../components/cards/AnimalCard';
+import { FaInfoCircle } from 'react-icons/fa'; 
+import Modal from './Modal';
 import './Strays.css';
 
 const Strays = () => {
@@ -11,7 +13,8 @@ const Strays = () => {
         gender: '',
         name: '',
     }) // State to store selected filters
-    const [debouncedFilters, setDebouncedFilters] = useState(filters) // Debounced state for filtering
+    const [debouncedFilters, setDebouncedFilters] = useState(filters)
+    const [showInfo, setShowInfo] = useState(false);
 
     // Debounce the filters so the API is not called on every keypress or select
     useEffect(() => {
@@ -73,15 +76,51 @@ const Strays = () => {
         }))
     }
 
+    const handleInfoClick = () => {
+        setShowInfo(true); // Show the modal
+    };
+
+    const handleCloseInfo = () => {
+        setShowInfo(false); // Close the modal
+    };
+
     return (
         <div className="container text-end">
-            {/* Render the filters */}
-            <MemoizedFilters
-                filters={filters}
-                handleFilterChange={handleFilterChange}
-            />
+            <div className="strays-header">
+                <div className="strays-info-icon-container">
+                    <FaInfoCircle
+                        className="strays-info-icon"
+                        onClick={handleInfoClick}
+                        title="Click for more info"
+                    />
+                </div>
+
+                {/* Render the filters */}
+                <MemoizedFilters
+                    filters={filters}
+                    handleFilterChange={handleFilterChange}
+                />
+            </div>
 
             {loading ? <Loader /> : <ReportList reports={reports} />}
+
+            {showInfo && (
+                <Modal onClose={handleCloseInfo}>
+                    <h2>About This Page</h2>
+                    <p>
+                        This page lists pets that have been seen by users but do not belong to the user posting it.
+                        Click the <strong>Read More</strong> button on each post to view detailed information, including:
+                    </p>
+                    <ul>
+                        <li>Where the pet was last seen (on a map).</li>
+                        <li>Other details about the pet like species, breed, color, and gender.</li>
+                        <li>As well as contant the post owner by clicking the message button.</li>
+                    </ul>
+                    <p>
+                        Users can only contact the post owner if logged in. Messaging helps determine whether the owner has seen the pet or currently has it in their possession.
+                    </p>
+                </Modal>
+            )}
         </div>
     )
 }

--- a/client/app/components/cards/FeaturedAnimals.js
+++ b/client/app/components/cards/FeaturedAnimals.js
@@ -73,7 +73,7 @@ const FeaturedStrays = () => {
 
     return (
         <div className="container text-end">
-            <div className="text-center h2 p-3">Featured Strays</div>
+            <div className="text-center h2 p-3">Strays Seen Near You</div>
             <hr />
 
             {/* Render the filters */}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0a5c96d8-eb9f-4490-b896-848aa5d58c43)


**Summary:**
- Added a "More Info" icon to the "All Strays" section of the `Strays` page.
- Implemented a modal to provide users with details about the purpose of the page and its functionality.
- Centered the modal header ("About This Page") and aligned the modal content to the left for better readability.
- Styled the "More Info" icon with a dark gray color (#6c757d) and hover effects for improved visibility and interactivity.
- Ensured all modal styles are scoped using a CSS module to avoid conflicts with other components.

**Purpose:**
This enhancement improves user understanding of the "All Strays" page, clarifying the distinction between user-posted pets and stray sightings. It provides a clear and user-friendly experience.
