### PR TITLE
Cloudinary test suites

### DIFF
--- a/server/cloudinary/config.js
+++ b/server/cloudinary/config.js
@@ -1,11 +1,24 @@
-const cloudinary = require('cloudinary').v2
-require('dotenv').config() // Ensure dotenv is loaded
+const cloudinary = require('cloudinary').v2;
+require('dotenv').config(); // Ensure dotenv is loaded
 
-// Configure Cloudinary using CLOUDINARY_URL
+// Check if CLOUDINARY_URL is defined and formatted correctly
+if (!process.env.CLOUDINARY_URL) {
+  throw new Error('CLOUDINARY_URL environment variable is not set');
+}
+
+// Use a regex to safely parse the CLOUDINARY_URL
+const cloudinaryUrl = process.env.CLOUDINARY_URL.match(
+  /cloudinary:\/\/([^:]+):([^@]+)@([^\/]+)/
+);
+
+if (!cloudinaryUrl) {
+  throw new Error('CLOUDINARY_URL is not in the expected format: cloudinary://api_key:api_secret@cloud_name');
+}
+
 cloudinary.config({
-    cloud_name: process.env.CLOUDINARY_URL.split('@')[1],
-    api_key: process.env.CLOUDINARY_URL.split('://')[1].split(':')[0],
-    api_secret: process.env.CLOUDINARY_URL.split(':')[2].split('@')[0],
-})
+  cloud_name: cloudinaryUrl[3], // cloud_name
+  api_key: cloudinaryUrl[1],   // api_key
+  api_secret: cloudinaryUrl[2], // api_secret
+});
 
-module.exports = cloudinary
+module.exports = cloudinary;

--- a/server/tests/profile.test.js
+++ b/server/tests/profile.test.js
@@ -1,0 +1,80 @@
+// tests/controllers/profile.test.js
+const { uploadProfileImage } = require('../../server/controllers/profile');
+const User = require('../../server/models/user');
+const uploadImage = require('../../server/cloudinary/upload');
+
+jest.mock('../../server/models/user');
+jest.mock('../../server/cloudinary/upload');
+
+describe('uploadProfileImage', () => {
+    let req, res;
+
+    beforeEach(() => {
+        req = {
+            file: { originalname: 'test.jpg' },
+            user: { _id: 'user123' },
+        };
+
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn(),
+        };
+
+        jest.clearAllMocks();
+    });
+
+    it('should return 400 if no file is provided', async () => {
+        req.file = null;
+
+        await uploadProfileImage(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ message: 'No image file provided' });
+    });
+
+    it('should upload the image and update the user profile', async () => {
+        const mockImageUrl = 'http://cloudinary.com/test.jpg';
+        const mockUser = { _id: 'user123', profileImage: mockImageUrl };
+
+        uploadImage.mockResolvedValue(mockImageUrl);
+        User.findByIdAndUpdate.mockResolvedValue(mockUser);
+
+        await uploadProfileImage(req, res);
+
+        expect(uploadImage).toHaveBeenCalledWith(req.file);
+        expect(User.findByIdAndUpdate).toHaveBeenCalledWith(
+            req.user._id,
+            { profileImage: mockImageUrl },
+            { new: true }
+        );
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith({ profileImage: mockImageUrl });
+    });
+
+    it('should return 404 if user is not found', async () => {
+        uploadImage.mockResolvedValue('http://cloudinary.com/test.jpg');
+        User.findByIdAndUpdate.mockResolvedValue(null);
+
+        await uploadProfileImage(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json).toHaveBeenCalledWith({ message: 'User not found' });
+    });
+
+    it('should return 500 if an error occurs', async () => {
+        const error = new Error('Database error');
+        jest.spyOn(console, 'error').mockImplementation(() => {}); // Suppress console.error
+    
+        uploadImage.mockResolvedValue('http://cloudinary.com/test.jpg');
+        User.findByIdAndUpdate.mockRejectedValue(error);
+    
+        await uploadProfileImage(req, res);
+    
+        expect(console.error).toHaveBeenCalledWith('Error uploading profile image:', error.message);
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ message: 'Failed to upload profile image' });
+    
+        console.error.mockRestore(); // Restore the original implementation
+    });
+});

--- a/server/tests/upload.test.js
+++ b/server/tests/upload.test.js
@@ -1,0 +1,44 @@
+// tests/cloudinary/upload.test.js
+const uploadImage = require('../../server/cloudinary/upload');
+const cloudinary = require('../../server/cloudinary/config');
+
+jest.mock('../../server/cloudinary/config', () => ({
+    uploader: {
+        upload_stream: jest.fn(),
+    },
+}));
+
+describe('uploadImage', () => {
+    it('should upload an image and return the URL', async () => {
+        const mockFile = { buffer: Buffer.from('mock file data') };
+        const mockUrl = 'http://cloudinary.com/mock-image.jpg';
+
+        // Mock the Cloudinary upload_stream behavior
+        cloudinary.uploader.upload_stream.mockImplementation((options, callback) => {
+            return {
+                end: () => {
+                    callback(null, { secure_url: mockUrl });
+                },
+            };
+        });
+
+        const result = await uploadImage(mockFile);
+        expect(result).toBe(mockUrl);
+    });
+
+    it('should reject with an error if the upload fails', async () => {
+        const mockFile = { buffer: Buffer.from('mock file data') };
+        const mockError = new Error('Upload failed');
+
+        // Mock the Cloudinary upload_stream to simulate an error
+        cloudinary.uploader.upload_stream.mockImplementation((options, callback) => {
+            return {
+                end: () => {
+                    callback(mockError, null);
+                },
+            };
+        });
+
+        await expect(uploadImage(mockFile)).rejects.toThrow('Upload failed');
+    });
+});


### PR DESCRIPTION
## UPDATED CLOUDINARY CONFIG FILE: 
![image](https://github.com/user-attachments/assets/3337db1e-149b-4093-8793-21e43af0eb2d)

Had to update this file because github would read 'split' as undefined. Instead of relying on .split() which can fail if the value is undefined, I used a more robust approach by checking the environment variable and extracting parts safely using regular expressions.
HAD TO UPDATE main YAML file to add CLOUDINARY_URL secret 

![image](https://github.com/user-attachments/assets/553b8f6d-1ca9-4533-86cf-74beb92feecc)
![image](https://github.com/user-attachments/assets/11baad21-e196-4860-90c5-8466e2da1f45)
![image](https://github.com/user-attachments/assets/f72ed931-e5bc-44a5-9ee5-21b1624d3a89)

Description
test suite additions
What's in this change?
Added 2 test suites for profile, and Cloudinary upload file

Testing changes
Run npm test -- upload.test.js profile.test.js --coverage for coverage of both both files together